### PR TITLE
Prepare release v0.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning][]. Full commit history is avai
 #### Added
 
 -   Added tests for the single-sample case {pr}`29`.
+-   Refer to issues and PRs with sphinx {pr}`30`.
 
 #### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,17 +11,34 @@ and this project adheres to [Semantic Versioning][]. Full commit history is avai
 
 ## Version 0.1
 
+### Unreleased
+
+### 0.1.3 (2025-02-07)
+
+#### Added
+
+-   Added tests for the single-sample case {pr}`29`.
+
+#### Removed
+
+-   Removed `tenacity` for query retries {pr}`28`.
+
+#### Fixed
+
+-   Fixed `_get_annotation_summary_string` for the single-sample case {pr}`29`.
+-   Fixed the expected cell type marker test by adding additional marker genes {pr}`28`.
+
 ### 0.1.2 (2025-01-29)
 
 #### Added
 
-- Update the documentation, in particular the installation instructions.
+-   Update the documentation, in particular the installation instructions.
 
 ### 0.1.1 (2025-01-29)
 
 #### Added
 
-- Initial push to PyPI
+-   Initial push to PyPI
 
 ### 0.1.0 (2025-01-29)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,29 +17,29 @@ and this project adheres to [Semantic Versioning][]. Full commit history is avai
 
 #### Added
 
--   Added tests for the single-sample case {pr}`29`.
--   Refer to issues and PRs with sphinx {pr}`30`.
+- Added tests for the single-sample case {pr}`29`.
+- Refer to issues and PRs with sphinx {pr}`30`.
 
 #### Removed
 
--   Removed `tenacity` for query retries {pr}`28`.
+- Removed `tenacity` for query retries {pr}`28`.
 
 #### Fixed
 
--   Fixed `_get_annotation_summary_string` for the single-sample case {pr}`29`.
--   Fixed the expected cell type marker test by adding additional marker genes {pr}`28`.
+- Fixed `_get_annotation_summary_string` for the single-sample case {pr}`29`.
+- Fixed the expected cell type marker test by adding additional marker genes {pr}`28`.
 
 ### 0.1.2 (2025-01-29)
 
 #### Added
 
--   Update the documentation, in particular the installation instructions.
+- Update the documentation, in particular the installation instructions.
 
 ### 0.1.1 (2025-01-29)
 
 #### Added
 
--   Initial push to PyPI
+- Initial push to PyPI
 
 ### 0.1.0 (2025-01-29)
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -59,6 +59,7 @@ extensions = [
     "IPython.sphinxext.ipython_console_highlighting",
     "sphinxext.opengraph",
     *[p.stem for p in (HERE / "extensions").glob("*.py")],
+    "sphinx.ext.extlinks",
 ]
 
 # autodoc + napoleon configuration
@@ -99,6 +100,13 @@ intersphinx_mapping = {
     "anndata": ("https://anndata.readthedocs.io/en/stable/", None),
     "scanpy": ("https://scanpy.readthedocs.io/en/stable/", None),
     "numpy": ("https://numpy.org/doc/stable/", None),
+}
+
+# extlinks config
+extlinks = {
+    "issue": (f"{repository_url}/issues/%s", "#%s"),
+    "pr": (f"{repository_url}/pull/%s", "#%s"),
+    "ghuser": ("https://github.com/%s", "@%s"),
 }
 
 # List of patterns, relative to source directory, that match files and


### PR DESCRIPTION
Modifies the CHANGELOG and allows referencing PRs and issues from it with sphinx. 