### PR TITLE
docs: fix Sphinx build warnings

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -15,7 +15,6 @@ The class :class:`~cell_annotator.CellAnnotator` is the main class that users in
 ```{eval-rst}
 The following classes are more technical; :class:`~cell_annotator.SampleAnnotator` is called under the hood for each sample, and :class:`~cell_annotator.BaseAnnotator` contains basic functionality.
 
-.. module:: cell_annotator
 .. currentmodule:: cell_annotator
 
 .. autosummary::

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -112,7 +112,7 @@ extlinks = {
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
 # This pattern also affects html_static_path and html_extra_path.
-exclude_patterns = ["_build", "Thumbs.db", ".DS_Store", "**.ipynb_checkpoints"]
+exclude_patterns = ["_build", "Thumbs.db", ".DS_Store", "**.ipynb_checkpoints", "notebooks/tests/**"]
 
 # -- Options for HTML output -------------------------------------------------
 
@@ -138,4 +138,6 @@ nitpick_ignore = [
     # If building the documentation fails because of a missing link that is outside your control,
     # you can add an exception to this list.
     #     ("py:class", "igraph.Graph"),
+    # Private Pydantic base used in provider type hints; not part of public API.
+    ("py:class", "cell_annotator._response_formats.BaseOutput"),
 ]

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -264,7 +264,7 @@ This project uses [sphinx][] with the following features:
 - [Numpy-style docstrings][numpydoc] (through the [napoloen][numpydoc-napoleon] extension).
 - Jupyter notebooks as tutorials through [myst-nb][] (See [Tutorials with myst-nb](#tutorials-with-myst-nb-and-jupyter-notebooks))
 - [sphinx-autodoc-typehints][], to automatically reference annotated input and output types
-- Citations (like {cite:p}`Virshup_2023`) can be included with [sphinxcontrib-bibtex](https://sphinxcontrib-bibtex.readthedocs.io/)
+- Citations (like {cite:p}`virshup2023scverse`) can be included with [sphinxcontrib-bibtex](https://sphinxcontrib-bibtex.readthedocs.io/)
 
 See scanpy’s {doc}`scanpy:dev/documentation` for more information on how to write your own.
 


### PR DESCRIPTION
Cleans up the 9 warnings currently emitted by `hatch run docs:build`, ahead of the rest of the cookiecutter-scverse v0.7.0 template sync (#73).

## Changes

- **`docs/api.md`** — drop the duplicate `.. module:: cell_annotator` directive that was producing `duplicate object description of cell_annotator, other instance in api`.
- **`docs/conf.py`** — add `notebooks/tests/**` to `exclude_patterns` so test notebooks (e.g. `ML_2025-07-26_cluster_coloring.ipynb`) are no longer pulled into the build. Fixes the `toc.not_included` warning.
- **`docs/conf.py`** — add `cell_annotator._response_formats.BaseOutput` to `nitpick_ignore`. It's a private Pydantic base used in provider type hints and intentionally not part of the public API, so 6 autodoc cross-references to it were failing to resolve.
- **`docs/contributing.md`** — fix the bibtex key from `Virshup_2023` to `virshup2023scverse` to match the entry in `docs/references.bib`.

## Validation

`rm -rf docs/_build docs/generated && uv run --extra doc sphinx-build -M html docs docs/_build` now reports `build succeeded.` with no warnings.

## Notes

Not enabling `-W` (warnings as errors) — intentionally left out, we'll revisit after the rest of the v0.7.0 sync lands.

Part of #73.
