### PR TITLE
build: adopt PEP 735 dependency groups for dev/test/doc

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -106,8 +106,11 @@ only because an outdated sphinx plugin pins an older version.
 To initalize a virtual environment in the `.venv` directory of your project, simply run
 
 ```bash
-uv sync --all-extras
+uv sync --all-extras --all-groups
 ```
+
+`--all-extras` pulls in the provider layers (openai, anthropic, gemini, …);
+`--all-groups` pulls in the `dev`, `test`, and `doc` PEP 735 dependency groups.
 
 The `.venv` directory is typically automatically discovered by IDEs such as VS Code.
 
@@ -122,10 +125,16 @@ we describe how you can manage environments manually using `pip`:
 ```bash
 python3 -m venv .venv
 source .venv/bin/activate
-pip install -e ".[dev,test,doc]"
+pip install --group dev --group test --group doc -e ".[test]"
 ```
 
 The `.venv` directory is typically automatically discovered by IDEs such as VS Code.
+
+Note: `pip install --group` requires pip >= 25.1 ([PEP 735][]).
+The `-e ".[test]"` extra pulls in the provider layers the test suite
+exercises; `--group` pulls in the dev / test / doc Python packages.
+
+[PEP 735]: https://peps.python.org/pep-0735/
 
 ::::
 :::::

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,12 +45,43 @@ optional-dependencies.anthropic = [
 optional-dependencies.colors = [
   "colorspacious>=1.1",
 ]
-# Development dependencies
-optional-dependencies.dev = [
+optional-dependencies.gemini = [
+  "google-genai>=1.27",
+]
+optional-dependencies.gpu = [
+  "rapids-singlecell>=0.12",
+]
+# Core provider dependencies - one of these is required to use the package
+optional-dependencies.openai = [
+  "openai>=1.90",
+]
+# Thin pointer so `pip install cell-annotator[test]` pulls in the provider extras
+# that the test suite exercises. Python test dependencies live in
+# [dependency-groups] test below and are pulled in by hatch / `uv sync --group test`.
+optional-dependencies.test = [
+  "cell-annotator[all-providers]",
+  "cell-annotator[colors]",
+]
+optional-dependencies.tutorials = [
+  "squidpy>=1.6",
+]
+# https://docs.pypi.org/project_metadata/#project-urls
+urls.Documentation = "https://cell-annotator.readthedocs.io/"
+urls.Homepage = "https://cell-annotator.readthedocs.io/"
+urls.Source = "https://github.com/quadbio/cell-annotator"
+
+[dependency-groups]
+dev = [
   "pre-commit",
   "twine>=4.0.2",
 ]
-optional-dependencies.doc = [
+test = [
+  "coverage>=7.10",
+  "flaky",
+  "pytest",
+  "pytest-cov",     # For VS Code's coverage functionality
+]
+doc = [
   "docutils>=0.8,!=0.18.*,!=0.19.*",
   "ipykernel",
   "ipython",
@@ -66,41 +97,20 @@ optional-dependencies.doc = [
   "sphinxcontrib-bibtex>=1",
   "sphinxext-opengraph",
 ]
-optional-dependencies.gemini = [
-  "google-genai>=1.27",
-]
-optional-dependencies.gpu = [
-  "rapids-singlecell>=0.12",
-]
-# Core provider dependencies - one of these is required to use the package
-optional-dependencies.openai = [
-  "openai>=1.90",
-]
-optional-dependencies.test = [
-  "cell-annotator[all-providers]", # tests use all providers
-  "cell-annotator[colors]",        # tests use color validation
-  "coverage>=7.10",
-  "flaky",
-  "pytest",
-  "pytest-cov",                    # For VS Code's coverage functionality
-]
-optional-dependencies.tutorials = [
-  "squidpy>=1.6",
-]
-# https://docs.pypi.org/project_metadata/#project-urls
-urls.Documentation = "https://cell-annotator.readthedocs.io/"
-urls.Homepage = "https://cell-annotator.readthedocs.io/"
-urls.Source = "https://github.com/quadbio/cell-annotator"
 
 [tool.hatch]
 envs.default.installer = "uv"
-envs.default.features = [ "dev" ]
-envs.docs.features = [ "doc" ]
+envs.default.dependency-groups = [ "dev" ]
+envs.docs.dependency-groups = [ "doc" ]
 envs.docs.dev-mode = true
 envs.docs.scripts.build = "sphinx-build -M html docs docs/_build {args}"
 envs.docs.scripts.open = "python -m webbrowser -t docs/_build/html/index.html"
 envs.docs.scripts.clean = "git clean -fdX -- {args:docs}"
-envs.hatch-test.features = [ "dev", "test" ]
+# hatch-test needs both:
+#   - dependency-groups: Python test packages (pytest, coverage, flaky, ...)
+#   - features: provider extras via optional-dependencies.test thin pointer
+envs.hatch-test.dependency-groups = [ "dev", "test" ]
+envs.hatch-test.features = [ "test" ]
 envs.hatch-test.matrix = [
   # Test the lowest and highest supported Python versions with normal deps
   { deps = [ "stable" ], python = [ "3.11", "3.13" ] },


### PR DESCRIPTION
Aligns cell-annotator with cookiecutter-scverse v0.7.0 by moving development-only dependencies from `[project.optional-dependencies]` to `[dependency-groups]` ([PEP 735](https://peps.python.org/pep-0735/)). Provider layers stay as `optional-dependencies` since end users install them via `pip install cell-annotator[openai]` etc.

## New layout

**`[dependency-groups]`** (dev-only — not shipped in the wheel metadata):
- `dev` = pre-commit, twine
- `test` = pytest, coverage, flaky, pytest-cov
- `doc` = Sphinx stack

**`[project.optional-dependencies]`** (install-time extras, unchanged for end users):
- provider layers: `openai`, `anthropic`, `gemini`, `all-providers`, `colors`, `gpu`, `tutorials`
- `test` — thinned to a pointer at `cell-annotator[all-providers]` + `cell-annotator[colors]`. The Python test packages no longer live here, so there's a single source of truth per audience.

**`[tool.hatch.envs.*]`** — switched `features = [...]` to `dependency-groups = [...]` for the `default`, `docs`, and `hatch-test` envs. `hatch-test` also keeps `features = [ "test" ]` so the provider extras flow in via the thin pointer above.

## Docs

- `docs/contributing.md` — pip recipe updated to `pip install --group dev --group test --group doc -e ".[test]"` (requires pip 25.1+).
- `docs/contributing.md` — uv recipe updated to `uv sync --all-extras --all-groups`.

## Validation

- `uv sync --all-extras --all-groups` resolves cleanly.
- `uv run --group test --extra test pytest` → **188 passed**.
- `hatch env show -i` renders the `hatch-test` matrix with the expected dependencies.
- `sphinx-build -M html docs docs/_build` succeeds with no warnings.

## Notes

- End users are unaffected: `pip install cell-annotator[openai]` still works exactly as before.
- External CI that installs `cell-annotator[test]` will continue to get the provider extras, but will now need to also pull `--group test` (or switch to uv / hatch) to get the Python test packages. We have no external consumer of `[test]` that I'm aware of.

Part of #73. Stacks on #74.
