### PR TITLE
chore: bump Python matrix to 3.11 + 3.14

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -62,9 +62,9 @@ This will list “Standalone” environments and a table of “Matrix” environ
 +------------+---------+--------------------------+----------+---------------------------------+-------------+
 | Name       | Type    | Envs                     | Features | Dependencies                    | Scripts     |
 +------------+---------+--------------------------+----------+---------------------------------+-------------+
-| hatch-test | virtual | hatch-test.py3.10-stable | dev      | coverage-enable-subprocess==1.0 | cov-combine |
-|            |         | hatch-test.py3.13-stable | test     | coverage[toml]~=7.4             | cov-report  |
-|            |         | hatch-test.py3.13-pre    |          | pytest-mock~=3.12               | run         |
+| hatch-test | virtual | hatch-test.py3.11-stable | dev      | coverage-enable-subprocess==1.0 | cov-combine |
+|            |         | hatch-test.py3.14-stable | test     | coverage[toml]~=7.4             | cov-report  |
+|            |         | hatch-test.py3.14-pre    |          | pytest-mock~=3.12               | run         |
 |            |         |                          |          | pytest-randomly~=3.15           | run-cov     |
 |            |         |                          |          | pytest-rerunfailures~=14.0      |             |
 |            |         |                          |          | pytest-xdist[psutil]~=3.5       |             |
@@ -73,18 +73,18 @@ This will list “Standalone” environments and a table of “Matrix” environ
 ```
 
 From the `Envs` column, select the environment name you want to use for development.
-In this example, it would be `hatch-test.py3.13-stable`.
+In this example, it would be `hatch-test.py3.14-stable`.
 
 Next, create the environment with
 
 ```bash
-hatch env create hatch-test.py3.13-stable
+hatch env create hatch-test.py3.14-stable
 ```
 
 Then, obtain the path to the environment using
 
 ```bash
-hatch env find hatch-test.py3.13-stable
+hatch env find hatch-test.py3.14-stable
 ```
 
 In case you are using VScode, now open the command palette (Ctrl+Shift+P) and search for `Python: Select Interpreter`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -113,9 +113,9 @@ envs.hatch-test.dependency-groups = [ "dev", "test" ]
 envs.hatch-test.features = [ "test" ]
 envs.hatch-test.matrix = [
   # Test the lowest and highest supported Python versions with normal deps
-  { deps = [ "stable" ], python = [ "3.11", "3.13" ] },
+  { deps = [ "stable" ], python = [ "3.11", "3.14" ] },
   # Test the newest supported Python version also with pre-release deps
-  { deps = [ "pre" ], python = [ "3.13" ] },
+  { deps = [ "pre" ], python = [ "3.14" ] },
 ]
 # If the matrix variable `deps` is set to "pre",
 # set the environment variable `UV_PRERELEASE` to "allow".


### PR DESCRIPTION
Sync `hatch-test` matrix with cookiecutter-scverse v0.7.0 template.

## Changes

- `pyproject.toml`: matrix now tests Python 3.11 (lowest) and 3.14 (highest) stable + 3.14 pre-release. Previously: 3.11/3.13 stable + 3.13 pre.
- `docs/contributing.md`: env table and command examples updated (`py3.10-stable`/`py3.13-stable`/`py3.13-pre` → `py3.11-stable`/`py3.14-stable`/`py3.14-pre`).

Classifiers already advertise 3.11–3.14, so no change there. Python 3.13 stable is dropped from CI; it sits in the supported middle of the range.

## Validation

- 141 non-LLM tests pass locally on Python 3.14.4 (all-providers,colors extras).
- Test ran in 41.6 s, 6 warnings unrelated to the Python version.

Part of #73.
