### PR TITLE
chore: sync with cookiecutter-scverse v0.7.0

### DIFF
--- a/.cruft.json
+++ b/.cruft.json
@@ -1,7 +1,7 @@
 {
   "template": "https://github.com/scverse/cookiecutter-scverse",
-  "commit": "d383d94fadff9e4e6fdb59d77c68cb900d7cedec",
-  "checkout": "v0.6.0",
+  "commit": "6ff5b92b5d44ea6d8a88e47538475718d467db95",
+  "checkout": "v0.7.0",
   "context": {
     "cookiecutter": {
       "project_name": "cell-annotator",
@@ -36,7 +36,7 @@
         "trim_blocks": true
       },
       "_template": "https://github.com/scverse/cookiecutter-scverse",
-      "_commit": "d383d94fadff9e4e6fdb59d77c68cb900d7cedec"
+      "_commit": "6ff5b92b5d44ea6d8a88e47538475718d467db95"
     }
   },
   "directory": null

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,6 +1,6 @@
 name: Bug report
 description: Report something that is broken or incorrect
-labels: bug
+type: Bug
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,6 +1,6 @@
 name: Feature request
 description: Propose a new feature for cell-annotator
-labels: enhancement
+type: Enhancement
 body:
   - type: textarea
     id: description

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -10,23 +10,16 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
-defaults:
-  run:
-    # to fail on error in multiline statements (-e), in pipes (-o pipefail), and on unset variables (-u).
-    shell: bash -euo pipefail {0}
-
 jobs:
   package:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           filter: blob:none
           fetch-depth: 0
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
-        with:
-          cache-dependency-glob: pyproject.toml
+        uses: astral-sh/setup-uv@v7
       - name: Build package
         run: uv build
       - name: Check package

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -4,11 +4,6 @@ on:
   release:
     types: [published]
 
-defaults:
-  run:
-    # to fail on error in multiline statements (-e), in pipes (-o pipefail), and on unset variables (-u).
-    shell: bash -euo pipefail {0}
-
 # Use "trusted publishing", see https://docs.pypi.org/trusted-publishers/
 jobs:
   release:
@@ -20,14 +15,12 @@ jobs:
     permissions:
       id-token: write # IMPORTANT: this permission is mandatory for trusted publishing
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           filter: blob:none
           fetch-depth: 0
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
-        with:
-          cache-dependency-glob: pyproject.toml
+        uses: astral-sh/setup-uv@v7
       - name: Build package
         run: uv build
       - name: Publish package distributions to PyPI

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -3,7 +3,8 @@ version: 2
 build:
   os: ubuntu-24.04
   tools:
-    python: "3.12"
+    python: "3.13"
+    nodejs: latest
   jobs:
     create_environment:
       - asdf plugin add uv


### PR DESCRIPTION
Final PR of the cookiecutter-scverse v0.7.0 sync (tracking issue #73).

## Changes

- **Issue templates** (`bug_report.yml`, `feature_request.yml`): `labels:` → `type:` — adopts GitHub's native issue-type field. Values capitalized (`Bug`, `Enhancement`) per template v0.7.0.
- **Workflows** (`build.yaml`, `release.yaml`): bump `actions/checkout@v4` → `v5` and `astral-sh/setup-uv@v5` → `v7`. Drop `cache-dependency-glob: pyproject.toml` (setup-uv@v7 handles caching automatically) and the per-workflow strict-bash `defaults.run` block (not in the template).
- **`.readthedocs.yaml`**: RTD Python 3.12 → 3.13, add `nodejs: latest` under `tools` (new template default).
- **`.cruft.json`**: bump pinned template to v0.7.0 (`6ff5b92`).

## Deliberately out of scope

Per the sync plan, these template v0.7.0 changes are **not** included (kept for separate future evaluation):

- Codecov OIDC migration
- Sphinx `-W` strict build flag
- katex docs extension

## Validation

- `git diff --stat`: 6 files, 11 insertions / 24 deletions.
- All edits match `scverse/cookiecutter-scverse@v0.7.0` template content verbatim (modulo project-specific substitutions).
- Previous sync PRs (#74, #75, #76) already covered Sphinx fixes, PEP 735 dep groups, and Python matrix bump.

Closes #73.
