### PR TITLE
fix: surface upstream provider errors in failure path

### DIFF
--- a/src/cell_annotator/_response_formats.py
+++ b/src/cell_annotator/_response_formats.py
@@ -10,8 +10,13 @@ class BaseOutput(BaseModel):
 
     @classmethod
     def default_failure(cls: type["BaseOutput"], failure_reason: str = "Manual fallback due to model failure."):
-        """Return a default output in case of failure, with a custom failure reason."""
-        return cls(reason_for_failure=failure_reason)
+        """Return a default output in case of failure, with a custom failure reason.
+
+        Uses ``model_construct`` so it cannot mask the upstream error with a
+        Pydantic ``ValidationError`` if a subclass declares a required field
+        without a default. Defaulted fields are still populated.
+        """
+        return cls.model_construct(reason_for_failure=failure_reason)
 
 
 class CellTypeColor(BaseOutput):

--- a/src/cell_annotator/model/_providers.py
+++ b/src/cell_annotator/model/_providers.py
@@ -70,6 +70,28 @@ class LLMProvider(ABC):
     def _list_models_impl(self) -> list[str]:
         """Provider-specific implementation for listing models."""
 
+    def _fail(
+        self,
+        response_format: type[BaseOutput],
+        failure_reason: str,
+        *,
+        exc: BaseException | None = None,
+    ) -> BaseOutput:
+        """
+        Build a failure response with consistent logging across providers.
+
+        Call this at every provider error boundary instead of
+        ``response_format.default_failure(...)`` directly. When ``exc`` is
+        given, the full traceback is recorded via ``exc_info=True`` so CI
+        logs contain enough context to diagnose upstream API errors.
+        """
+        provider_name = self.__class__.__name__
+        if exc is not None:
+            logger.error("[%s] %s", provider_name, failure_reason, exc_info=True)
+        else:
+            logger.warning("[%s] %s", provider_name, failure_reason)
+        return response_format.default_failure(failure_reason=failure_reason)
+
 
 class OpenAIProvider(LLMProvider):
     """OpenAI provider implementation."""
@@ -184,17 +206,15 @@ class OpenAIProvider(LLMProvider):
             if response.parsed:
                 return response.parsed
             elif response.refusal:
-                failure_reason = "Model refused to respond: %s"
-                logger.warning(failure_reason, response.refusal)
-                return response_format.default_failure(failure_reason=failure_reason % response.refusal)
+                return self._fail(response_format, f"Model refused to respond: {response.refusal}")
             else:
-                failure_reason = "Unknown model failure."
-                logger.warning(failure_reason)
-                return response_format.default_failure(failure_reason=failure_reason)
-        except openai.LengthFinishReasonError:
-            failure_reason = "Maximum number of tokens exceeded. Try increasing `max_completion_tokens`."
-            logger.warning(failure_reason)
-            return response_format.default_failure(failure_reason=failure_reason)
+                return self._fail(response_format, "Unknown model failure.")
+        except openai.LengthFinishReasonError as e:
+            return self._fail(
+                response_format,
+                "Maximum number of tokens exceeded. Try increasing `max_completion_tokens`.",
+                exc=e,
+            )
         except openai.OpenAIError as e:
             logger.warning(
                 "Structured parse failed for model '%s'. Falling back to JSON-mode query. Error: %s", model, str(e)
@@ -297,10 +317,9 @@ class OpenAIProvider(LLMProvider):
             raw_content = completion.choices[0].message.content
             text = self._coerce_text_content(raw_content)
             if not text:
-                return response_format.default_failure(
-                    failure_reason=(
-                        f"Model returned empty content during JSON fallback. Original parse error: {fallback_error}"
-                    )
+                return self._fail(
+                    response_format,
+                    f"Model returned empty content during JSON fallback. Original parse error: {fallback_error}",
                 )
 
             # Strict JSON parsing first.
@@ -341,19 +360,17 @@ class OpenAIProvider(LLMProvider):
                             except Exception:  # noqa: BLE001
                                 pass
 
-            return response_format.default_failure(
-                failure_reason=(
-                    "Could not parse structured JSON response from model output. "
-                    f"Original parse error: {fallback_error}"
-                )
+            return self._fail(
+                response_format,
+                f"Could not parse structured JSON response from model output. Original parse error: {fallback_error}",
             )
         except Exception as fallback_exception:  # noqa: BLE001
-            return response_format.default_failure(
-                failure_reason=(
-                    "Fallback JSON query failed. "
-                    f"Original parse error: {fallback_error}. "
-                    f"Fallback error: {str(fallback_exception)}"
-                )
+            return self._fail(
+                response_format,
+                "Fallback JSON query failed. "
+                f"Original parse error: {fallback_error}. "
+                f"Fallback error: {str(fallback_exception)}",
+                exc=fallback_exception,
             )
 
     def _coerce_text_content(self, content) -> str:
@@ -564,13 +581,10 @@ class GeminiProvider(LLMProvider):
             if hasattr(response, "parsed") and response.parsed:
                 return response.parsed
             else:
-                # Fallback if parsing fails
-                failure_reason = "Gemini failed to parse structured response"
-                return response_format.default_failure(failure_reason=failure_reason)
+                return self._fail(response_format, "Gemini failed to parse structured response")
 
         except (ValueError, TypeError, KeyError) as e:
-            failure_reason = f"Gemini API error: {str(e)}"
-            return response_format.default_failure(failure_reason=failure_reason)
+            return self._fail(response_format, f"Gemini API error: {str(e)}", exc=e)
 
 
 class AnthropicProvider(LLMProvider):
@@ -681,16 +695,20 @@ class AnthropicProvider(LLMProvider):
                             if isinstance(input_data, dict):
                                 return response_format(**input_data)
 
-            # Fallback if no tool use found
-            failure_reason = "No structured response found in tool use output"
-            return response_format.default_failure(failure_reason=failure_reason)
+            # No tool_use block — Claude either refused or returned plain text.
+            # Capture stop_reason and content-block types so CI logs can tell the difference.
+            stop_reason = getattr(response, "stop_reason", "<unknown>")
+            block_types = [getattr(b, "type", "<unknown>") for b in (response.content or [])]
+            return self._fail(
+                response_format,
+                f"No structured response found in tool use output "
+                f"(stop_reason={stop_reason!r}, content_block_types={block_types})",
+            )
 
         except anthropic.AnthropicError as e:
-            failure_reason = f"Anthropic API error: {str(e)}"
-            return response_format.default_failure(failure_reason=failure_reason)
+            return self._fail(response_format, f"Anthropic API error: {str(e)}", exc=e)
         except (ValueError, TypeError, KeyError) as e:
-            failure_reason = f"Response parsing error: {str(e)}"
-            return response_format.default_failure(failure_reason=failure_reason)
+            return self._fail(response_format, f"Response parsing error: {str(e)}", exc=e)
 
 
 # Provider registry - initialize lazily to avoid import errors


### PR DESCRIPTION
## Summary

PR #80 (a no-op `pre-commit autoupdate`) is currently red because 5 real-LLM **Anthropic** tests fail on `main`. Same 5 failures exist on `main` since #71 — they're independent of #80. The visible failure (`pydantic ValidationError: SimpleOutput.text Field required`) is a **masked error**: the test's `SimpleOutput` declares `text: str` with no default, and when the Anthropic call raises an `AnthropicError`, `BaseOutput.default_failure` re-validates and produces a `ValidationError` *about the failure object itself*. That hides the real Anthropic API error from CI logs, so we can't tell *why* Anthropic fails.

This PR doesn't disable any tests. It makes the underlying error visible across **all** providers (per project preference for generic, modular fixes over per-provider patches), so a follow-up can fix the root cause.

- `BaseOutput.default_failure` → uses `cls.model_construct(...)` instead of full Pydantic validation. The failure object can never again mask the upstream cause. Production schemas all declare defaults, so behaviour is unchanged.
- New `LLMProvider._fail(response_format, reason, *, exc=None)` helper centralises logging across `OpenAIProvider`, `GeminiProvider`, `AnthropicProvider` (`OpenRouterProvider` inherits OpenAI's path). Uses `logger.error(..., exc_info=True)` when an exception is passed, `logger.warning(...)` otherwise — replaces the existing inconsistent mix (OpenAI logged `str(e)` with no traceback; Gemini/Anthropic logged nothing).
- All 11 `default_failure` call sites in the four providers now route through `self._fail`.
- Anthropic's "no tool use found" fallback also captures `response.stop_reason` and `content_block_types` so logs can distinguish "Claude refused" / "plain text returned" / "empty tool input".

## Test plan

- [x] `uv run pytest -m "not real_llm_query"` — 154 passed locally
- [ ] CI green on all hatch matrix environments
- [ ] Anthropic real-LLM tests still fail (expected — this PR exposes the root cause, doesn't fix it), and the failure logs now contain a provider-tagged `ERROR [AnthropicProvider] ...` line with full traceback
- [ ] Read those logs and open a follow-up to fix the underlying Anthropic issue (likely candidates: bump default model, dated model alias, tool-schema sanitisation, or retry/backoff)

🤖 Generated with [Claude Code](https://claude.com/claude-code)