### PR TITLE
ci: make pre-release test job non-blocking

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -60,6 +60,8 @@ jobs:
 
     name: ${{ matrix.env.label }}
     runs-on: ${{ matrix.os }}
+    # Allow pre-release tests to fail without blocking the PR (dependency compatibility issues)
+    continue-on-error: ${{ contains(matrix.env.name, 'pre') }}
 
     env:
       OS: ${{ matrix.os }}


### PR DESCRIPTION
## What
Mark the `hatch-test.*-pre (PRE-RELEASE DEPENDENCIES)` matrix legs `continue-on-error`, so a failing pre-release environment no longer fails the required `Tests pass in all hatch environments` gate.

## Why
The `py3.14-pre` job runs with `UV_PRERELEASE=allow` and currently **blocks merges** whenever an upstream pre-release dependency is incompatible — e.g. PR #82 is blocked by a **pandas pre-release** change (Categorical backing arrays became read-only), which fails 3 tests in `test_obs_beautifier.py::test_reorder_categories_with_nan_values`. That failure:
- is **upstream-driven**, not caused by any PR (it pre-exists on `main` — a scheduled run on the same SHA passed before the pandas pre-release and failed after), and
- has no soft-fail escape hatch here, unlike the sister repo `cellmapper` (whose workflow already marks the pre job `continue-on-error`).

This change brings the workflow in line with `cellmapper`: the pre-release job stays a **visible early-warning signal** but stops gating merges. The `alls-green` gate then passes because a `continue-on-error` matrix leg doesn't count as a failure.

## Effect
Unblocks PR #82 and any future PR while the upstream pandas pre-release incompatibility persists. (Optionally, the test could later be hardened against read-only Categorical backing so the pre signal goes green legitimately — out of scope here.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)