### PR TITLE
Fix read-only error in NaN reorder test under pandas >=3

### DIFF
--- a/tests/model/test_obs_beautifier.py
+++ b/tests/model/test_obs_beautifier.py
@@ -69,9 +69,14 @@ class TestObsBeautifier:
         adata = cell_annotator.adata
 
         # Set up initial annotations with a NaN value
-        adata.obs["leiden"] = adata.obs["leiden"].map({"0": "B cells", "1": "T cells"}).astype("category")
-        # Add a NaN value
-        adata.obs.loc[adata.obs.index[0], "leiden"] = np.nan
+        leiden = adata.obs["leiden"].map({"0": "B cells", "1": "T cells"}).astype("category")
+        # Inject a NaN via a writable copy + full-column reassignment rather than an in-place
+        # `.loc` write. anndata subsetting (here sc.pp.filter_cells in the fixture) leaves obs
+        # backing arrays read-only, and pandas >=3 refuses in-place mutation of them
+        # ("ValueError: assignment destination is read-only"). Reassigning the column avoids it.
+        leiden = leiden.copy()
+        leiden.iloc[0] = np.nan
+        adata.obs["leiden"] = leiden
 
         nan_count_before = adata.obs["leiden"].isna().sum()
         assert nan_count_before > 0


### PR DESCRIPTION
## What
Fix `test_reorder_categories_with_nan_values`, which fails only in the `py3.14-pre (PRE-RELEASE DEPENDENCIES)` CI job with:

```
ValueError: assignment destination is read-only
```

## Root cause
The test injected a NaN with an in-place write:
```python
adata.obs.loc[adata.obs.index[0], "leiden"] = np.nan
```
The fixture (`get_example_data`) runs `sc.pp.filter_cells`, which **subsets** the AnnData; anndata leaves the resulting `obs` backing arrays **read-only**. **pandas >= 3** strictly refuses in-place mutation of read-only arrays, so the assignment raises. (On pandas 2.x the in-place write silently copied, so it passed — hence this only surfaced once a pandas 3 pre-release entered the pre-release matrix.)

This is a real forward-compatibility issue with the test's mutation pattern, not a masking workaround. The package code itself is unaffected — `reorder_categories` reassigns whole columns via `cat.set_categories`.

## Fix
Inject the NaN on a writable copy and reassign the whole column:
```python
leiden = adata.obs["leiden"].map({"0": "B cells", "1": "T cells"}).astype("category")
leiden = leiden.copy()
leiden.iloc[0] = np.nan
adata.obs["leiden"] = leiden
```
Test intent (reorder must preserve NaNs) is unchanged.

## Verification
Reproduced faithfully (AnnData + `sc.pp.filter_cells` + the assignment) on **pandas 3.0.3**: the old pattern raises `assignment destination is read-only`; the new pattern succeeds (`nan_count == 1`). CI on this PR exercises the real `py3.14-pre` job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)